### PR TITLE
Restrict jobs to 1 for compilation for SMTCoq

### DIFF
--- a/packages/coq:smtcoq/coq:smtcoq.dev/opam
+++ b/packages/coq:smtcoq/coq:smtcoq.dev/opam
@@ -10,7 +10,7 @@ authors: [
 ]
 build: [
   ["sh" "-c" "cd src && ./configure.sh -standard"]
-  ["sh" "-c" "cd src && make -j%{jobs}%"]
+  ["sh" "-c" "cd src && make -j1"]
   ["sh" "-c" "cd src && make install"]
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SMTCoq"]


### PR DESCRIPTION
It seems that dependencies are currently badly handled with multi-threaded compilation, I thus restricted to one job.